### PR TITLE
init(plan): init plan to deploy JIMM via terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore transient lock info files created by terraform apply
+.terraform.tfstate.lock.info
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,35 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.7.1"
+  hashes = [
+    "h1:/qtweZW2sk0kBNiQM02RvBXmlVdI9oYqRMCyBZ8XA98=",
+    "zh:3193b89b43bf5805493e290374cdda5132578de6535f8009547c8b5d7a351585",
+    "zh:3218320de4be943e5812ed3de995946056db86eb8d03aa3f074e0c7316599bef",
+    "zh:419861805a37fa443e7d63b69fb3279926ccf98a79d256c422d5d82f0f387d1d",
+    "zh:4df9bd9d839b8fc11a3b8098a604b9b46e2235eb65ef15f4432bde0e175f9ca6",
+    "zh:5814be3f9c9cc39d2955d6f083bae793050d75c572e70ca11ccceb5517ced6b1",
+    "zh:63c6548a06de1231c8ee5570e42ca09c4b3db336578ded39b938f2156f06dd2e",
+    "zh:697e434c6bdee0502cc3deb098263b8dcd63948e8a96d61722811628dce2eba1",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a0b8e44927e6327852bbfdc9d408d802569367f1e22a95bcdd7181b1c3b07601",
+    "zh:b7d3af018683ef22794eea9c218bc72d7c35a2b3ede9233b69653b3c782ee436",
+    "zh:d63b911d618a6fe446c65bfc21e793a7663e934b2fef833d42d3ccd38dd8d68d",
+    "zh:fa985cd0b11e6d651f47cff3055f0a9fd085ec190b6dbe99bf5448174434cdea",
+  ]
+}
+
+provider "registry.terraform.io/juju/juju" {
+  version     = "0.17.1"
+  constraints = ">= 0.17.1"
+  hashes = [
+    "h1:qXQDbZWKvJ3IF8uc5m+lj/PWzFBGxvNc/nTSq4VDwuc=",
+    "zh:0881614ddb5f8498b7752f3588363e5be890cbc7d1dedc0fd278dbbb68b4aad4",
+    "zh:3d157a733a0e35dbf140db3a797c35dc95304009c464348e7496421f79e65ff5",
+    "zh:753ad16d007180a77a147bd377de2fb334f409123f6fee36d4c50c7fe8b76a29",
+    "zh:9d3220cf11b3ca67c40a8fd3eb31966607ba6dec486114549c14272d16b81e3c",
+    "zh:cf9c998d0fb8c56d6f779f26e2b7f004ea9dcc8979d1e2e14eac2fb06ba4a29b",
+    "zh:d5ec44036b7c35436e54130c729c50ba0f02a2082b789f0414209723c050bdfb",
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,61 @@
-init file otherwise i can't fork the repo
+# JIMM terraform plan
+This is the terraform plan to deploy  [JIMM](https://canonical-jaas-documentation.readthedocs-hosted.com/en/v3/).
+
+## Requirements
+
+- juju microk8s controller: https://microk8s.io/docs/getting-started
+  > Make sure metallb add-ons is enabled: https://microk8s.io/docs/addon-metallb
+- vault client:  https://snapcraft.io/vault
+- terraform client: https://snapcraft.io/terraform
+- valid client_id/client_secret for oauth: An example is to use Google https://developers.google.com/identity/protocols/oauth2/limited-input-device#creatingcred
+
+## Deploy
+
+- in `main.tf@juju provider` you can set the fields to connect to your microk8s juju controller. 
+    > If you have the Juju CLI set up on your machine, you don't need to set any credentials because terraform will pick those up using your juju CLI from the controller you are currently switched to.
+- After having generated the client_id and client_secret you can create a file called `secrets.tfvars` with this format:
+  ```
+  client_id     = "<client_id>"
+  client_secret = ">client_secret>"
+  ```
+
+Now you can setup terraform:
+`terraform init`
+
+Check out the plan:
+`terraform plan`
+
+Apply it:
+`terraform apply -var-file=secrets.tfvars`
+
+You have to unseal vault:
+https://charmhub.io/vault-k8s/docs/h-getting-started#h-4-set-up-the-vault-cli
+
+
+Now, everything should be `active`.
+
+> If JIMM is blocked waiting for the Vault relation, change a setting to force a restart.
+> Ex: `juju config jimm juju-dashboard-location=""`
+
+If you run:
+`juju run ingress/0 show-proxied-endpoints` you should see the endpoint for JIMM.
+
+Find the IP address traefik exposes your services on:
+`kubectl get service ingress-lb -n jimm` -> look for `external_ip`
+
+Add JIMM's endpoint to your `/etc/hosts`:
+`sudo echo <external_ip> jimm.localhost.com >> /etc/hosts`
+> The reason why you need a .com domain is that most OAuth provider 
+
+Import JIMM's certificate to your host machine:
+```
+juju run jimm-cert/0 get-ca-certificate --quiet | yq .ca-certificate | sudo tee /usr/local/share/ca-certificates/jimm-test.crt 
+sudo update-ca-certificates --fresh
+```
+
+Now test JIMM:  
+`curl https://jimm.localhost.com/jimm-jimm/debug/status`
+
+`juju login jimm.localhost.com:443/jimm-jimm -c jimm-k8s` -> prompts you to login into Google
+
+

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,67 @@
+terraform {
+  required_providers {
+    juju = {
+      source  = "registry.terraform.io/juju/juju"
+      version = ">= 0.17.1"
+    }
+  }
+}
+
+provider "juju" {}
+
+variable "client_id" {
+  description = "client id for oauth provider"
+  type        = string
+}
+
+variable "client_secret" {
+  description = "client secret for oauth provider"
+  type        = string
+}
+
+resource "juju_model" "jimm" {
+  name = "jimm"
+}
+
+module "postgresql" {
+  source     = "./modules/postgresql"
+  depends_on = [juju_model.jimm]
+}
+
+module "openfga" {
+  source     = "./modules/openfga"
+  depends_on = [juju_model.jimm]
+}
+
+module "cert" {
+  source     = "./modules/cert"
+  depends_on = [juju_model.jimm]
+}
+
+module "traefik" {
+  source            = "./modules/traefik"
+  depends_on        = [juju_model.jimm]
+  external_hostname = "jimm.localhost.com"
+}
+
+module "vault" {
+  source     = "./modules/vault"
+  depends_on = [juju_model.jimm]
+}
+
+
+module "jimm" {
+  source          = "./modules/jimm"
+  oauth_offer_url = ""
+  client_id       = var.client_id
+  client_secret   = var.client_secret
+  jimm_config = {
+    uuid        = "3f4d142b-732e-4e99-80e7-5899b7e67e59"
+    dns_name    = "test-jimm.localhost"
+    public_key  = "eaj1OMeHsd8OyDTqE+OOpkmWCNd1Py6mF1i3UD+VoCk=" # this will eventually be a secret
+    private_key = "vx+aEalWSM524h9NAZcyZlUFvOLkiRN2J7K5uz9FW1c=" # this will eventually be a secret
+  }
+  depends_on = [juju_model.jimm]
+}
+
+

--- a/modules/cert/main.tf
+++ b/modules/cert/main.tf
@@ -1,0 +1,17 @@
+data "juju_model" "model" {
+  name = var.model
+}
+
+resource "juju_application" "jimm-cert" {
+  model = data.juju_model.model.name
+  name  = var.name
+  trust = var.trust
+  units = var.units
+
+  charm {
+    name    = var.charm.name
+    channel = var.charm.channel
+    base    = var.charm.base
+  }
+}
+

--- a/modules/cert/outputs.tf
+++ b/modules/cert/outputs.tf
@@ -1,0 +1,5 @@
+output "name" {
+  description = "The name of the Juju self-signed cert application."
+  value       = juju_application.jimm-cert.name
+}
+

--- a/modules/cert/provider.tf
+++ b/modules/cert/provider.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.17.0"
+    }
+  }
+}

--- a/modules/cert/variables.tf
+++ b/modules/cert/variables.tf
@@ -1,0 +1,42 @@
+variable "model" {
+  description = "The name of the Juju model."
+  type        = string
+  default     = "jimm"
+}
+
+variable "name" {
+  description = "The name of the Juju cert application."
+  type        = string
+  default     = "jimm-cert"
+}
+
+variable "units" {
+  description = "The desired Juju unit count to deploy."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.units > 0
+    error_message = "The unit count must be a positive integer."
+  }
+}
+
+variable "trust" {
+  description = "The status to grant the Juju application full access to the cluster."
+  type        = bool
+  default     = true
+}
+
+variable "charm" {
+  description = "The application charm operator information."
+  type = object({
+    name : string
+    channel : string
+    base : string
+  })
+  default = {
+    name    = "self-signed-certificates"
+    channel = "latest/stable"
+    base    = "ubuntu@22.04"
+  }
+}

--- a/modules/jimm/integrations.tf
+++ b/modules/jimm/integrations.tf
@@ -1,0 +1,65 @@
+### Integrations ###
+resource "juju_integration" "jimm_openfga" {
+  model = var.model
+
+  application {
+    name     = juju_application.jimm.name
+    endpoint = "openfga"
+  }
+
+  application {
+    name = var.openfga_application_name
+  }
+}
+
+resource "juju_integration" "jimm_ingress" {
+  model = var.model
+
+  application {
+    name     = juju_application.jimm.name
+    endpoint = "ingress"
+  }
+
+  application {
+    name = var.ingress_application_name
+  }
+}
+
+resource "juju_integration" "jimm_vault" {
+  model = var.model
+
+  application {
+    name     = juju_application.jimm.name
+    endpoint = "vault"
+  }
+
+  application {
+    name = var.vault_application_name
+  }
+}
+
+resource "juju_integration" "jimm_postgresql" {
+  model = var.model
+
+  application {
+    name     = juju_application.jimm.name
+    endpoint = "database"
+  }
+
+  application {
+    name = var.postgresql_application_name
+  }
+}
+
+resource "juju_integration" "jimm_oauth" {
+  model = var.model
+  application {
+    name     = juju_application.jimm.name
+    endpoint = "oauth"
+  }
+
+  application {
+    name = juju_application.oauth-external-idp-integrator.name
+  }
+}
+

--- a/modules/jimm/main.tf
+++ b/modules/jimm/main.tf
@@ -1,0 +1,59 @@
+### Applications ###
+resource "juju_application" "jimm" {
+  name  = var.name
+  model = var.model
+  trust = var.trust
+  units = var.units
+
+  charm {
+    name    = var.charm.name
+    channel = var.charm.channel
+    base    = var.charm.base
+  }
+
+  config = {
+    uuid                    = var.jimm_config.uuid == "" ? random_uuid.jimm-uuid[0].result : var.jimm_config.uuid
+    controller-admins       = var.jimm_config.controller_admins
+    log-level               = var.jimm_config.log_level
+    dns-name                = var.jimm_config.dns_name
+    postgres-secret-storage = false
+    public-key              = var.jimm_config.public_key
+    private-key             = var.jimm_config.private_key
+  }
+
+}
+
+resource "juju_application" "oauth-external-idp-integrator" {
+  name  = var.oauth-external-idp-integrator_application_name
+  model = var.model
+  trust = true
+
+  charm {
+    name     = "oauth-external-idp-integrator"
+    channel  = var.oauth-external-idp-integrator_charm_channel
+    revision = var.oauth-external-idp-integrator_charm_revision
+    base     = var.oauth-external-idp-integrator_charm_base
+  }
+
+  config = {
+    client_id              = var.client_id
+    client_secret          = var.client_secret
+    issuer_url             = var.oauth-external-idp-integrator_config.issuer_url
+    authorization_endpoint = var.oauth-external-idp-integrator_config.authorization_endpoint
+    introspection_endpoint = var.oauth-external-idp-integrator_config.introspection_endpoint
+    jwks_endpoint          = var.oauth-external-idp-integrator_config.jwks_endpoint
+    token_endpoint         = var.oauth-external-idp-integrator_config.token_endpoint
+    userinfo_endpoint      = var.oauth-external-idp-integrator_config.userinfo_endpoint
+    scope                  = var.oauth-external-idp-integrator_config.scope
+  }
+
+  units = 1
+}
+
+### Misc ###
+
+resource "random_uuid" "jimm-uuid" {
+  count = var.jimm_config.uuid == "" ? 1 : 0
+}
+
+

--- a/modules/jimm/provider.tf
+++ b/modules/jimm/provider.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.17.0"
+    }
+  }
+}

--- a/modules/jimm/variables.tf
+++ b/modules/jimm/variables.tf
@@ -1,0 +1,155 @@
+variable "os_region" {
+  type    = string
+  default = "prodstack6"
+}
+
+
+variable "model" {
+  type    = string
+  default = "jimm"
+}
+
+variable "name" {
+  description = "JIMM application name"
+  type        = string
+  default     = "jimm"
+}
+
+variable "trust" {
+  description = "The status to grant the Juju application full access to the cluster."
+  type        = bool
+  default     = true
+}
+
+variable "client_id" {
+  type = string
+}
+
+variable "client_secret" {
+  type = string
+}
+
+
+variable "charm" {
+  description = "The application charm operator information."
+  type = object({
+    name : string
+    channel : string
+    base : string
+  })
+  default = {
+    name    = "juju-jimm-k8s"
+    channel = "3/edge"
+    base    = "ubuntu@22.04"
+  }
+}
+
+variable "jimm_config" {
+  type = object({
+    uuid              = optional(string, "")
+    controller_admins = optional(string, "")
+    log_level         = optional(string, "info")
+    dns_name          = string
+    public_key        = string
+    private_key       = string
+  })
+  description = <<EOT
+    jimm_config = {
+      uuid: "The UUID advertised by the JIMM controller. If not provided, one will be generated for you."
+      controller_admins: "Whitespace separated list of candid users (or groups) that are made controller admins by default."
+      log_level: "Level to out log messages at, one of debug, info, warn, error, dpanic, panic, and fatal."
+      dns_name: "DNS hostname that JIMM is being served from."
+    }
+  EOT
+}
+
+variable "units" {
+  description = "Number of JIMM units"
+  type        = number
+  default     = 1
+}
+
+variable "oauth-external-idp-integrator_application_name" {
+  description = "Oauth External Idp Integrator application name"
+  type        = string
+  default     = "idp-integrator"
+}
+
+variable "oauth-external-idp-integrator_charm_channel" {
+  description = "Oauth External Idp Integrator charm channel"
+  type        = string
+  default     = "latest/edge"
+}
+
+variable "oauth-external-idp-integrator_charm_revision" {
+  description = "Oauth External Idp Integrator charm revision"
+  type        = number
+  default     = 6
+}
+
+variable "oauth-external-idp-integrator_charm_base" {
+  description = "Oauth External Idp Integrator charm base"
+  type        = string
+  default     = "ubuntu@22.04"
+}
+
+variable "oauth-external-idp-integrator_config" {
+  type = object({
+    issuer_url             = string
+    authorization_endpoint = string
+    introspection_endpoint = string
+    jwks_endpoint          = string
+    token_endpoint         = string
+    userinfo_endpoint      = string
+    scope                  = string
+  })
+  description = <<EOT
+    oauth-external-idp-integrator_config = {
+      issuer_url: ""
+      authorization_endpoint: ""
+      introspection_endpoint: ""
+      jwks_endpoint: ""
+      token_endpoint: ""
+      userinfo_endpoint: ""
+      scope: ""
+    }
+  EOT
+  default = {
+    # https://developers.google.com/identity/openid-connect/openid-connect#discovery
+    issuer_url             = "https://accounts.google.com"
+    authorization_endpoint = "https://accounts.google.com/o/oauth2/v2/auth"
+    introspection_endpoint = "https://www.googleapis.com/oauth2/v1/tokeninfo"
+    jwks_endpoint          = "https://www.googleapis.com/oauth2/v3/certs"
+    token_endpoint         = "https://oauth2.googleapis.com/token"
+    userinfo_endpoint      = "https://openidconnect.googleapis.com/v1/userinfo"
+    scope                  = "openid profile email"
+  }
+}
+
+variable "oauth_offer_url" {
+  description = "OAuth Offer URL"
+  type        = string
+  default     = ""
+}
+
+variable "openfga_application_name" {
+  type    = string
+  default = "openfga"
+}
+
+variable "vault_application_name" {
+  type    = string
+  default = "vault"
+}
+
+variable "postgresql_application_name" {
+  type    = string
+  default = "postgresql"
+}
+
+variable "ingress_application_name" {
+  type    = string
+  default = "ingress"
+}
+
+

--- a/modules/openfga/integrations.tf
+++ b/modules/openfga/integrations.tf
@@ -1,0 +1,12 @@
+resource "juju_integration" "openfga_postgresql" {
+  model = var.model
+
+  application {
+    name     = juju_application.openfga.name
+    endpoint = "database"
+  }
+
+  application {
+    name = var.postgresql_application_name
+  }
+}

--- a/modules/openfga/main.tf
+++ b/modules/openfga/main.tf
@@ -1,0 +1,18 @@
+data "juju_model" "model" {
+  name = var.model
+}
+
+
+resource "juju_application" "openfga" {
+  model = data.juju_model.model.name
+  name  = var.name
+  trust = var.trust
+  units = var.units
+
+  charm {
+    name    = var.charm.name
+    channel = var.charm.channel
+    base    = var.charm.base
+  }
+}
+

--- a/modules/openfga/outputs.tf
+++ b/modules/openfga/outputs.tf
@@ -1,0 +1,5 @@
+output "name" {
+  description = "The name of the Juju OpenFGA application."
+  value       = juju_application.openfga.name
+}
+

--- a/modules/openfga/provider.tf
+++ b/modules/openfga/provider.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.17.0"
+    }
+  }
+}

--- a/modules/openfga/variables.tf
+++ b/modules/openfga/variables.tf
@@ -1,0 +1,47 @@
+variable "model" {
+  description = "The name of the Juju model."
+  type        = string
+  default     = "jimm"
+}
+
+variable "name" {
+  description = "The name of the Juju openfga application."
+  type        = string
+  default     = "openfga"
+}
+
+variable "units" {
+  description = "The desired Juju unit count to deploy."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.units > 0
+    error_message = "The unit count must be a positive integer."
+  }
+}
+
+variable "trust" {
+  description = "The status to grant the Juju application full access to the cluster."
+  type        = bool
+  default     = true
+}
+
+variable "charm" {
+  description = "The application charm operator information."
+  type = object({
+    name : string
+    channel : string
+    base : string
+  })
+  default = {
+    name    = "openfga-k8s"
+    channel = "latest/stable"
+    base    = "ubuntu@22.04"
+  }
+}
+
+variable "postgresql_application_name" {
+  type    = string
+  default = "postgresql"
+}

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -1,0 +1,23 @@
+data "juju_model" "model" {
+  name = var.model
+}
+
+
+resource "juju_application" "postgresql" {
+  model = data.juju_model.model.name
+  name  = var.name
+  trust = var.trust
+  units = var.units
+
+  charm {
+    name    = var.charm.name
+    channel = var.charm.channel
+    base    = var.charm.base
+  }
+
+  config = {
+    plugin_pg_trgm_enable   = true
+    plugin_uuid_ossp_enable = true
+    plugin_btree_gin_enable = true
+  }
+}

--- a/modules/postgresql/outputs.tf
+++ b/modules/postgresql/outputs.tf
@@ -1,0 +1,4 @@
+output "name" {
+  description = "The name of the Juju PostgreSQL application."
+  value       = juju_application.postgresql.name
+}

--- a/modules/postgresql/provider.tf
+++ b/modules/postgresql/provider.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.17.0"
+    }
+  }
+}

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -1,0 +1,42 @@
+variable "model" {
+  description = "The name of the Juju model."
+  type        = string
+  default     = "jimm"
+}
+
+variable "name" {
+  description = "The name of the Juju postgresql application."
+  type        = string
+  default     = "postgresql"
+}
+
+variable "units" {
+  description = "The desired Juju unit count to deploy."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.units > 0
+    error_message = "The unit count must be a positive integer."
+  }
+}
+
+variable "trust" {
+  description = "The status to grant the Juju application full access to the cluster."
+  type        = bool
+  default     = true
+}
+
+variable "charm" {
+  description = "The application charm operator information."
+  type = object({
+    name : string
+    channel : string
+    base : string
+  })
+  default = {
+    name    = "postgresql-k8s"
+    channel = "14/stable"
+    base    = "ubuntu@22.04"
+  }
+}

--- a/modules/traefik/integrations.tf
+++ b/modules/traefik/integrations.tf
@@ -1,0 +1,13 @@
+resource "juju_integration" "ingress_cert" {
+  model = var.model
+
+  application {
+    name     = juju_application.traefik.name
+    endpoint = "certificates"
+  }
+
+  application {
+    name     = var.cert_application_name
+    endpoint = "certificates"
+  }
+}

--- a/modules/traefik/main.tf
+++ b/modules/traefik/main.tf
@@ -1,0 +1,21 @@
+data "juju_model" "model" {
+  name = var.model
+}
+
+resource "juju_application" "traefik" {
+  model = data.juju_model.model.name
+  name  = var.name
+  trust = var.trust
+  units = var.units
+
+  charm {
+    name    = var.charm.name
+    channel = var.charm.channel
+    base    = var.charm.base
+  }
+
+  config = {
+    external_hostname = var.external_hostname
+    routing_mode      = var.routing_mode
+  }
+}

--- a/modules/traefik/outputs.tf
+++ b/modules/traefik/outputs.tf
@@ -1,0 +1,4 @@
+output "name" {
+  description = "The name of the Juju Traefik application."
+  value       = juju_application.traefik.name
+}

--- a/modules/traefik/provider.tf
+++ b/modules/traefik/provider.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.17.0"
+    }
+  }
+}

--- a/modules/traefik/variables.tf
+++ b/modules/traefik/variables.tf
@@ -1,0 +1,59 @@
+variable "model" {
+  description = "The name of the Juju model."
+  type        = string
+  default     = "jimm"
+}
+
+variable "name" {
+  description = "The name of the Juju ingress application."
+  type        = string
+  default     = "ingress"
+}
+
+variable "units" {
+  description = "The desired Juju unit count to deploy."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.units > 0
+    error_message = "The unit count must be a positive integer."
+  }
+}
+
+variable "trust" {
+  description = "The status to grant the Juju application full access to the cluster."
+  type        = bool
+  default     = true
+}
+
+variable "charm" {
+  description = "The application charm operator information."
+  type = object({
+    name : string
+    channel : string
+    base : string
+  })
+  default = {
+    name    = "traefik-k8s"
+    channel = "latest/edge"
+    base    = "ubuntu@20.04"
+  }
+}
+
+variable "external_hostname" {
+  description = "The DNS name to be used by Traefik ingress."
+  type        = string
+  default     = ""
+}
+
+variable "routing_mode" {
+  description = "The routing mode used by Traefik ingress."
+  type        = string
+  default     = "path"
+}
+
+variable "cert_application_name" {
+  type    = string
+  default = "jimm-cert"
+}

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -1,0 +1,18 @@
+data "juju_model" "model" {
+  name = var.model
+}
+
+
+resource "juju_application" "vault" {
+  model = data.juju_model.model.name
+  name  = var.name
+  trust = var.trust
+  units = var.units
+
+  charm {
+    name    = var.charm.name
+    channel = var.charm.channel
+    base    = var.charm.base
+  }
+}
+

--- a/modules/vault/outputs.tf
+++ b/modules/vault/outputs.tf
@@ -1,0 +1,5 @@
+output "name" {
+  description = "The name of the Juju Vault application."
+  value       = juju_application.vault.name
+}
+

--- a/modules/vault/provider.tf
+++ b/modules/vault/provider.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.17.0"
+    }
+  }
+}

--- a/modules/vault/variables.tf
+++ b/modules/vault/variables.tf
@@ -1,0 +1,42 @@
+variable "model" {
+  description = "The name of the Juju model."
+  type        = string
+  default     = "jimm"
+}
+
+variable "name" {
+  description = "The name of the Juju vault application."
+  type        = string
+  default     = "vault"
+}
+
+variable "units" {
+  description = "The desired Juju unit count to deploy."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.units > 0
+    error_message = "The unit count must be a positive integer."
+  }
+}
+
+variable "trust" {
+  description = "The status to grant the Juju application full access to the cluster."
+  type        = bool
+  default     = true
+}
+
+variable "charm" {
+  description = "The application charm operator information."
+  type = object({
+    name : string
+    channel : string
+    base : string
+  })
+  default = {
+    name    = "vault-k8s"
+    channel = "1.16/stable"
+    base    = "ubuntu@22.04"
+  }
+}


### PR DESCRIPTION
In this PR we create a plan to deploy JIMM via a Juju Microk8s controller and the external identity provider.

The approach I've used is to divide the different applications in different modules.
I've c/p what I could from https://github.com/canonical/cd-identity-core-infrastructure/tree/main